### PR TITLE
added getVoltLow

### DIFF
--- a/src/I2C_BM8563.cpp
+++ b/src/I2C_BM8563.cpp
@@ -13,6 +13,12 @@ void I2C_BM8563::begin(void) {
   _i2cPort->endTransmission();
 }
 
+bool I2C_BM8563::getVoltLow()
+{
+    uint8_t data = ReadReg(0x02);
+    return data & 0x80; // RTCC_VLSEC_MASK
+}
+
 uint8_t I2C_BM8563::bcd2ToByte(uint8_t value) {
   uint8_t tmp = 0;
   tmp = ((uint8_t)(value & (uint8_t)0xF0) >> (uint8_t)0x4) * 10;

--- a/src/I2C_BM8563.h
+++ b/src/I2C_BM8563.h
@@ -25,6 +25,7 @@ class I2C_BM8563 {
     I2C_BM8563(uint8_t deviceAddress = I2C_BM8563_DEFAULT_ADDRESS, TwoWire &i2cPort = Wire);
 
     void begin(void);
+    bool getVoltLow();
 
     void getTime(I2C_BM8563_TimeTypeDef* I2C_BM8563_TimeStruct);
     void getDate(I2C_BM8563_DateTypeDef* I2C_BM8563_DateStruct);


### PR DESCRIPTION
Detects if the voltage went low. This is reset when the time is set again.

This is a usefull function to combine with NTP: only call NTP when the time needs to be checked again

if (rtc.getVoltLow())
  {
    set_ntp_time();
  }